### PR TITLE
Fix: Reestructurar render.yaml para despliegue de sitio estático

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,9 +18,8 @@ services:
         value: 3.11
       # La siguiente variable se inyecta automáticamente con la URL del frontend
       - key: FRONTEND_URL
-        fromService:
-          # Se ha eliminado el "type: static" que causaba el error
-          name: inmo-frontend # Debe coincidir con el nombre del servicio de frontend
+        fromStaticSite:
+          name: inmo-frontend # Apunta al sitio estático definido abajo
           property: url
       # --- ¡IMPORTANTE! Añade los siguientes valores en el Dashboard de Render ---
       - key: MONGO_URI
@@ -34,9 +33,9 @@ services:
       - key: ADMIN_TOKEN
         sync: false
 
-  # ---------------- Frontend Service (React/Vite Static Site) ----------------
-  - type: static
-    name: inmo-frontend
+# ---------------- Frontend Service (React/Vite Static Site) ----------------
+static_sites:
+  - name: inmo-frontend
     env: node
     rootDir: frontend
     plan: free


### PR DESCRIPTION
Se reestructura el archivo `render.yaml` para alinear su configuración con la especificación correcta de Render para el despliegue de sitios estáticos, lo que soluciona los errores 'unknown type'.

- La configuración del frontend (`inmo-frontend`) se ha movido de la sección `services` a una nueva sección de nivel superior `static_sites`.
- La referencia de la variable de entorno `FRONTEND_URL` en el backend se ha actualizado para usar `fromStaticSite` en lugar de `fromService`.

Este cambio corrige los errores de tipo de servicio y debería permitir un despliegue exitoso.