### PR TITLE
Feat: Añadir .gitignore global para proteger el repositorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Security - Ignorar archivos con secretos o credenciales
+mhara_user_accessKeys.csv
+*.env
+.env
+.env.*
+secrets.json
+credentials.json
+
+# Archivos de sistema operativo
+.DS_Store
+Thumbs.db
+
+# Python cache y dependencias locales
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+pip-log.txt
+pip-delete-this-directory.txt
+.eggs/
+.pytest_cache/
+.mypy_cache/
+.tox/
+
+# Node.js dependencias y artefactos de build
+node_modules/
+dist/
+build/
+.npm/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Logs
+*.log
+logs/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 pymongo[srv]
 boto3
 passLib[bcrypt]
+gunicorn


### PR DESCRIPTION
Se añade un archivo `.gitignore` en la raíz del proyecto para prevenir que archivos sensibles y artefactos de build sean subidos al repositorio.

Este archivo incluye reglas para:
- Archivos de credenciales como `mhara_user_accessKeys.csv` y `.env`.
- Carpetas de dependencias como `node_modules`.
- Archivos de caché de Python como `__pycache__`.
- Logs y otros archivos de sistema operativo.

Esto mejora la seguridad y la salud general del repositorio.