### PR TITLE
Fix: Añadir email-validator como dependencia

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ pymongo[srv]
 boto3
 passLib[bcrypt]
 gunicorn
+email-validator


### PR DESCRIPTION
Se añade `email-validator` al archivo `backend/requirements.txt` para solucionar el `ModuleNotFoundError` que ocurría durante el inicio de la aplicación en Render.

La validación de emails en Pydantic requiere esta dependencia explícita.