### PR TITLE
feat: Add responsive CSS structure

### DIFF
--- a/frontend/src/components/AdvisorsCard/AdvisorCard.module.css
+++ b/frontend/src/components/AdvisorsCard/AdvisorCard.module.css
@@ -1,74 +1,80 @@
-/* Contenedor de la tarjeta */
-.card {
-    background-color: rgba(255, 255, 255, 0.9);
-    border-radius: 20px;
-    padding: 30px;
-    text-align: center;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    position: relative;
-    width: 20rem;
-    height: 390px;
-    margin: 20px; /* Agrega un margen entre las tarjetas */
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
 }
 
-/* Imagen del asesor */
-.advisorImage {
-    width: 140px;
-    height: 140px;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 1px solid #fff;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    margin-top: -20px; /* Mueve la imagen para que se superponga al borde de la tarjeta */
-    position: relative;
-    background-color: #f1f1f1;
-    background-repeat: no-repeat;
-    background-size: 140px; /* Ajusta el tamaño del icono a 70px */
-    background-position: center; /* Centra el icono */
-}
+@media (min-width: 768px) {
+  /* Contenedor de la tarjeta */
+  .card {
+      background-color: rgba(255, 255, 255, 0.9);
+      border-radius: 20px;
+      padding: 30px;
+      text-align: center;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+      position: relative;
+      width: 20rem;
+      height: 390px;
+      margin: 20px; /* Agrega un margen entre las tarjetas */
+  }
 
-.advisorName {
-    margin-top: 15px;
-    font-size: 1.2rem;
-    color: #333;
-}
+  /* Imagen del asesor */
+  .advisorImage {
+      width: 140px;
+      height: 140px;
+      border-radius: 50%;
+      object-fit: cover;
+      border: 1px solid #fff;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+      margin-top: -20px; /* Mueve la imagen para que se superponga al borde de la tarjeta */
+      position: relative;
+      background-color: #f1f1f1;
+      background-repeat: no-repeat;
+      background-size: 140px; /* Ajusta el tamaño del icono a 70px */
+      background-position: center; /* Centra el icono */
+  }
 
-.testimonial {
-    font-size: 1rem;
-    color: #555;
-    line-height: 1.5;
-    margin-top: 20px;
-    text-align: left;
-    flex-grow: 1;
-}
+  .advisorName {
+      margin-top: 15px;
+      font-size: 1.2rem;
+      color: #333;
+  }
 
-.contactContainer {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 12px;
-    margin-top: 20px;
-    width: 100%;
-    padding-left: 10px; /* Indent the contact info slightly */
-}
+  .testimonial {
+      font-size: 1rem;
+      color: #555;
+      line-height: 1.5;
+      margin-top: 20px;
+      text-align: left;
+      flex-grow: 1;
+  }
 
-.contactLink {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    text-decoration: none;
-    color: #333;
-    font-size: 0.9rem;
-    transition: color 0.2s ease;
-}
+  .contactContainer {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 12px;
+      margin-top: 20px;
+      width: 100%;
+      padding-left: 10px; /* Indent the contact info slightly */
+  }
 
-.contactLink:hover {
-    color: #007bff;
-}
+  .contactLink {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      text-decoration: none;
+      color: #333;
+      font-size: 0.9rem;
+      transition: color 0.2s ease;
+  }
 
-.contactLink svg {
-    font-size: 1.2rem;
-    color: #555;
-    width: 20px; /* Ensure icons are aligned */
-    text-align: center;
+  .contactLink:hover {
+      color: #007bff;
+  }
+
+  .contactLink svg {
+      font-size: 1.2rem;
+      color: #555;
+      width: 20px; /* Ensure icons are aligned */
+      text-align: center;
+  }
 }

--- a/frontend/src/components/DropdownMenu/DropdownMenu.css
+++ b/frontend/src/components/DropdownMenu/DropdownMenu.css
@@ -1,25 +1,31 @@
-.dropdown-menu {
-    position: fixed;
-    top: 60px; /* Adjust as needed */
-    right: 10px;
-    background-color: white;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
 }
 
-.dropdown-menu ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
+@media (min-width: 768px) {
+  .dropdown-menu {
+      position: fixed;
+      top: 60px; /* Adjust as needed */
+      right: 10px;
+      background-color: white;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  }
 
-.dropdown-menu li {
-    padding: 8px 20px;
-    cursor: pointer;
-    font-size: 16px;
-}
+  .dropdown-menu ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+  }
 
-.dropdown-menu li:hover {
-    background-color: #f5f5f5;
+  .dropdown-menu li {
+      padding: 8px 20px;
+      cursor: pointer;
+      font-size: 16px;
+  }
+
+  .dropdown-menu li:hover {
+      background-color: #f5f5f5;
+  }
 }

--- a/frontend/src/components/GlassmorphismButton/GlassmorphismButton.css
+++ b/frontend/src/components/GlassmorphismButton/GlassmorphismButton.css
@@ -1,22 +1,28 @@
-.glassmorphism-button {
-    width: 100%;
-    padding: 25px 25px;
-    font-size: 1.2em;
-    font-weight: 600;
-    color: #333;
-    cursor: pointer;
-    border: none;
-    background: rgba(255, 255, 255, 0.459);
-    backdrop-filter: blur(2px);
-    -webkit-backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 20px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    transition: transform 0.2s ease, background 0.2s ease;
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
 }
 
-.glassmorphism-button:hover {
-    transform: translateY(-3px);
-    background: rgba(255, 255, 255, 0.4);
-    color: black;
+@media (min-width: 768px) {
+  .glassmorphism-button {
+      width: 100%;
+      padding: 25px 25px;
+      font-size: 1.2em;
+      font-weight: 600;
+      color: #333;
+      cursor: pointer;
+      border: none;
+      background: rgba(255, 255, 255, 0.459);
+      backdrop-filter: blur(2px);
+      -webkit-backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      border-radius: 20px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      transition: transform 0.2s ease, background 0.2s ease;
+  }
+
+  .glassmorphism-button:hover {
+      transform: translateY(-3px);
+      background: rgba(255, 255, 255, 0.4);
+      color: black;
+  }
 }

--- a/frontend/src/components/InputWithIcon/InputWithIcon.css
+++ b/frontend/src/components/InputWithIcon/InputWithIcon.css
@@ -1,26 +1,32 @@
-.input-container {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    margin: 10px 0;
-    background-color: #fff;
-    border-radius: 10px;
-    padding: 10px 15px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-    color: black;
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
 }
 
-.input-icon {
-    width: 20px;
-    margin-right: 5px;
-    opacity: 0.7;
-}
+@media (min-width: 768px) {
+  .input-container {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      margin: 10px 0;
+      background-color: #fff;
+      border-radius: 10px;
+      padding: 10px 15px;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+      color: black;
+  }
 
-.input-field {
-    flex-grow: 1;
-    border: none;
-    outline: none;
-    background: transparent;
-    font-size: 0.86em;
-    color: black;
+  .input-icon {
+      width: 20px;
+      margin-right: 5px;
+      opacity: 0.7;
+  }
+
+  .input-field {
+      flex-grow: 1;
+      border: none;
+      outline: none;
+      background: transparent;
+      font-size: 0.86em;
+      color: black;
+  }
 }

--- a/frontend/src/components/PropertyCard/PropertyCard.module.css
+++ b/frontend/src/components/PropertyCard/PropertyCard.module.css
@@ -1,59 +1,65 @@
-.propertyCard {
-    display: flex;
-    margin-bottom: 10px;
-    background-color: #333;
-    border-radius: 5px;
-    overflow: hidden;
-    cursor: pointer;
-    transition: background-color 0.3s;
-    height: 90px;
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
 }
 
-.propertyCard:hover {
-    background-color: #444;
-}
+@media (min-width: 768px) {
+  .propertyCard {
+      display: flex;
+      margin-bottom: 10px;
+      background-color: #333;
+      border-radius: 5px;
+      overflow: hidden;
+      cursor: pointer;
+      transition: background-color 0.3s;
+      height: 90px;
+  }
 
-.propertyImage {
-    width: 120px;
-    height: 90px;
-    object-fit: cover;
-}
+  .propertyCard:hover {
+      background-color: #444;
+  }
 
-.propertyInfo {
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    flex-grow: 1;
-}
+  .propertyImage {
+      width: 120px;
+      height: 90px;
+      object-fit: cover;
+  }
 
-.infoLine {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
+  .propertyInfo {
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      flex-grow: 1;
+  }
 
-.address {
-    font-size: 0.9em;
-    color: #ccc;
-    margin: 0;
-}
+  .infoLine {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+  }
 
-.price {
-    font-weight: bold;
-    font-size: 1em;
-    margin: 0;
-}
+  .address {
+      font-size: 0.9em;
+      color: #ccc;
+      margin: 0;
+  }
 
-.favoriteButton {
-    background: none;
-    border: none;
-    color: #ccc; /* Corazón vacío */
-    cursor: pointer;
-    font-size: 1.2rem;
-    padding: 0;
-}
+  .price {
+      font-weight: bold;
+      font-size: 1em;
+      margin: 0;
+  }
 
-.favoriteButton.isFavorite {
-    color: #ff9900; /* Corazón relleno */
+  .favoriteButton {
+      background: none;
+      border: none;
+      color: #ccc; /* Corazón vacío */
+      cursor: pointer;
+      font-size: 1.2rem;
+      padding: 0;
+  }
+
+  .favoriteButton.isFavorite {
+      color: #ff9900; /* Corazón relleno */
+  }
 }

--- a/frontend/src/pages/AboutUs/AboutUs.css
+++ b/frontend/src/pages/AboutUs/AboutUs.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400..700&display=swap');
 
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
+}
+
 /* Base styles for mobile (350px) */
 .about-us-container {
     background-color: white;

--- a/frontend/src/pages/AdvisorProfile/AdvisorProfile.css
+++ b/frontend/src/pages/AdvisorProfile/AdvisorProfile.css
@@ -1,3 +1,7 @@
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
+}
+
 /* Base styles for mobile (350px) */
 .advisor-profile-container {
     background-color: #f0f2f5;

--- a/frontend/src/pages/Catalogo/Catalogo.css
+++ b/frontend/src/pages/Catalogo/Catalogo.css
@@ -1,3 +1,7 @@
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
+}
+
 /* Mobile First Styles (350px) */
 .catalogo-container {
     display: flex;

--- a/frontend/src/pages/Home/home.css
+++ b/frontend/src/pages/Home/home.css
@@ -1,3 +1,7 @@
+@media (min-width: 375px) {
+  /* User-provided styles will go here */
+}
+
 /* Base styles for mobile (350px) */
 body {
     padding: 0;


### PR DESCRIPTION
This change prepares all CSS files for a mobile-first responsive design, as requested by the user.

For CSS files that were not already responsive, the existing styles have been wrapped in a `@media (min-width: 768px)` media query to target desktop screens.

For all CSS files, an empty `@media (min-width: 375px)` media query has been added to serve as a placeholder for mobile-specific styles.

This provides a consistent structure across all stylesheets for implementing the new responsive design.