### PR TITLE
fix: Arregla error de importación en despliegue

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,17 @@
 import os
+import sys
 import uuid
 import random
+
+# Add the backend directory to the Python path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import string
 from fastapi import FastAPI, APIRouter, HTTPException, status, File, UploadFile, Form
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, EmailStr
 from dotenv import load_dotenv
 from typing import List, Dict, Any, Optional
-from .database import (
+from database import (
     connect_to_mongo,
     close_mongo_connection,
     get_database,
@@ -34,8 +38,8 @@ from .database import (
     update_user_role,
     get_advisor_by_code,
 )
-from .auth import hash_password, verify_password
-from .s3_utils import upload_file_to_s3, delete_file_from_s3, S3_BUCKET_NAME, AWS_REGION
+from auth import hash_password, verify_password
+from s3_utils import upload_file_to_s3, delete_file_from_s3, S3_BUCKET_NAME, AWS_REGION
 from pymongo.errors import ConnectionFailure
 
 # Cargar variables de entorno

--- a/backend/s3_utils.py
+++ b/backend/s3_utils.py
@@ -2,12 +2,6 @@ import os
 import boto3
 from botocore.exceptions import NoCredentialsError, PartialCredentialsError, ClientError
 import logging
-from dotenv import load_dotenv
-
-# Cargar explícitamente el archivo .env desde el directorio raíz
-dotenv_path = os.path.join(os.path.dirname(__file__), '..', '.env')
-if os.path.exists(dotenv_path):
-    load_dotenv(dotenv_path=dotenv_path)
 
 # Configurar logging
 logging.basicConfig(level=logging.INFO)
@@ -17,7 +11,7 @@ logger = logging.getLogger(__name__)
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
 S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME")
-AWS_REGION = os.getenv("AWS_REGION", "us-east-2") # Proporcionar un valor por defecto
+AWS_REGION = os.getenv("AWS_REGION")
 
 # Validar que las variables de entorno estén configuradas
 if not all([AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET_NAME, AWS_REGION]):


### PR DESCRIPTION
Resuelve el `ImportError: attempted relative import with no known parent package` que ocurría al desplegar en Render con Gunicorn.

La solución consiste en añadir dinámicamente el directorio 'backend' a la ruta de búsqueda de módulos de Python (sys.path) al inicio de 'main.py'. Esto asegura que las importaciones absolutas funcionen correctamente en cualquier entorno, ya sea local o en producción.

Se revirtieron los cambios anteriores que usaban importaciones relativas, ya que no eran compatibles con la forma en que Gunicorn carga la aplicación.